### PR TITLE
Add AVX-512 intrinsic-backed instructions

### DIFF
--- a/src/avx_512.rs
+++ b/src/avx_512.rs
@@ -1,0 +1,199 @@
+use crate::ast::{ArgType, Argument, FunctionRegistry, Instruction};
+use std::arch::x86_64::*;
+
+fn m512i_to_argument(value: __m512i) -> Argument {
+    let lanes: [i64; 8] = unsafe { std::mem::transmute(value) };
+    let mut bytes = [0u8; 64];
+    for (i, &lane) in lanes.iter().enumerate() {
+        let lane_bytes = lane.to_le_bytes();
+        let start = i * 8;
+        bytes[start..start + 8].copy_from_slice(&lane_bytes);
+    }
+    Argument::Array(ArgType::I512, bytes)
+}
+
+#[inline]
+fn require_avx512f() -> Result<(), String> {
+    if !is_x86_feature_detected!("avx512f") {
+        Err("AVX-512F not supported on this CPU/runtime".to_string())
+    } else {
+        Ok(())
+    }
+}
+
+#[inline]
+fn require_avx512dq() -> Result<(), String> {
+    if !is_x86_feature_detected!("avx512dq") {
+        Err("AVX-512DQ not supported on this CPU/runtime".to_string())
+    } else {
+        Ok(())
+    }
+}
+
+pub fn register_avx512_instructions(registry: &mut FunctionRegistry) {
+    // set1/broadcast
+    registry.register_instruction(Instruction::new(
+        "_mm512_set1_epi32",
+        vec![ArgType::U32],
+        ArgType::I512,
+        |_, args| {
+            require_avx512f()?;
+            if args.len() != 1 {
+                return Err("_mm512_set1_epi32 requires 1 argument".to_string());
+            }
+            let v = args[0].to_u32() as i32;
+            let res = unsafe { _mm512_set1_epi32(v) };
+            Ok(m512i_to_argument(res))
+        },
+    ));
+
+    registry.register_instruction(Instruction::new(
+        "_mm512_set1_epi64",
+        vec![ArgType::U64],
+        ArgType::I512,
+        |_, args| {
+            require_avx512f()?;
+            require_avx512dq()?;
+            if args.len() != 1 {
+                return Err("_mm512_set1_epi64 requires 1 argument".to_string());
+            }
+            let v = args[0].to_u64() as i64;
+            let res = unsafe { _mm512_set1_epi64(v) };
+            Ok(m512i_to_argument(res))
+        },
+    ));
+
+    // add
+    registry.register_instruction(Instruction::new(
+        "_mm512_add_epi32",
+        vec![ArgType::I512, ArgType::I512],
+        ArgType::I512,
+        |_, args| {
+            require_avx512f()?;
+            if args.len() != 2 {
+                return Err("_mm512_add_epi32 requires 2 arguments".to_string());
+            }
+            let a = args[0].to_i512();
+            let b = args[1].to_i512();
+            let res = unsafe { _mm512_add_epi32(a, b) };
+            Ok(m512i_to_argument(res))
+        },
+    ));
+
+    registry.register_instruction(Instruction::new(
+        "_mm512_add_epi64",
+        vec![ArgType::I512, ArgType::I512],
+        ArgType::I512,
+        |_, args| {
+            require_avx512f()?;
+            require_avx512dq()?;
+            if args.len() != 2 {
+                return Err("_mm512_add_epi64 requires 2 arguments".to_string());
+            }
+            let a = args[0].to_i512();
+            let b = args[1].to_i512();
+            let res = unsafe { _mm512_add_epi64(a, b) };
+            Ok(m512i_to_argument(res))
+        },
+    ));
+
+    // sub
+    registry.register_instruction(Instruction::new(
+        "_mm512_sub_epi32",
+        vec![ArgType::I512, ArgType::I512],
+        ArgType::I512,
+        |_, args| {
+            require_avx512f()?;
+            if args.len() != 2 {
+                return Err("_mm512_sub_epi32 requires 2 arguments".to_string());
+            }
+            let a = args[0].to_i512();
+            let b = args[1].to_i512();
+            let res = unsafe { _mm512_sub_epi32(a, b) };
+            Ok(m512i_to_argument(res))
+        },
+    ));
+
+    registry.register_instruction(Instruction::new(
+        "_mm512_sub_epi64",
+        vec![ArgType::I512, ArgType::I512],
+        ArgType::I512,
+        |_, args| {
+            require_avx512f()?;
+            require_avx512dq()?;
+            if args.len() != 2 {
+                return Err("_mm512_sub_epi64 requires 2 arguments".to_string());
+            }
+            let a = args[0].to_i512();
+            let b = args[1].to_i512();
+            let res = unsafe { _mm512_sub_epi64(a, b) };
+            Ok(m512i_to_argument(res))
+        },
+    ));
+
+    // mullo (32-bit)
+    registry.register_instruction(Instruction::new(
+        "_mm512_mullo_epi32",
+        vec![ArgType::I512, ArgType::I512],
+        ArgType::I512,
+        |_, args| {
+            require_avx512f()?;
+            if args.len() != 2 {
+                return Err("_mm512_mullo_epi32 requires 2 arguments".to_string());
+            }
+            let a = args[0].to_i512();
+            let b = args[1].to_i512();
+            let res = unsafe { _mm512_mullo_epi32(a, b) };
+            Ok(m512i_to_argument(res))
+        },
+    ));
+
+    // logical operations
+    registry.register_instruction(Instruction::new(
+        "_mm512_and_si512",
+        vec![ArgType::I512, ArgType::I512],
+        ArgType::I512,
+        |_, args| {
+            require_avx512f()?;
+            if args.len() != 2 {
+                return Err("_mm512_and_si512 requires 2 arguments".to_string());
+            }
+            let a = args[0].to_i512();
+            let b = args[1].to_i512();
+            let res = unsafe { _mm512_and_si512(a, b) };
+            Ok(m512i_to_argument(res))
+        },
+    ));
+
+    registry.register_instruction(Instruction::new(
+        "_mm512_or_si512",
+        vec![ArgType::I512, ArgType::I512],
+        ArgType::I512,
+        |_, args| {
+            require_avx512f()?;
+            if args.len() != 2 {
+                return Err("_mm512_or_si512 requires 2 arguments".to_string());
+            }
+            let a = args[0].to_i512();
+            let b = args[1].to_i512();
+            let res = unsafe { _mm512_or_si512(a, b) };
+            Ok(m512i_to_argument(res))
+        },
+    ));
+
+    registry.register_instruction(Instruction::new(
+        "_mm512_xor_si512",
+        vec![ArgType::I512, ArgType::I512],
+        ArgType::I512,
+        |_, args| {
+            require_avx512f()?;
+            if args.len() != 2 {
+                return Err("_mm512_xor_si512 requires 2 arguments".to_string());
+            }
+            let a = args[0].to_i512();
+            let b = args[1].to_i512();
+            let res = unsafe { _mm512_xor_si512(a, b) };
+            Ok(m512i_to_argument(res))
+        },
+    ));
+}

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1,4 +1,5 @@
 use crate::ast::*;
+use crate::avx_512::register_avx512_instructions;
 use crate::avx2::register_avx2_instructions;
 use crate::bmi2::register_bmi2_instructions;
 use std::arch::x86_64::*;
@@ -225,6 +226,8 @@ impl Interpreter {
 
         // Register AVX2 intrinsic-backed instructions
         register_avx2_instructions(&mut registry);
+        // Register AVX-512 intrinsic-backed instructions
+        register_avx512_instructions(&mut registry);
         // Register BMI2 intrinsic-backed instructions
         register_bmi2_instructions(&mut registry);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod ast;
 mod avx2;
+mod avx_512;
 mod bmi2;
 mod display;
 mod interpreter;


### PR DESCRIPTION
## Summary
- add a dedicated `avx_512` module that exposes AVX-512 integer intrinsics through the interpreter registry
- integrate the AVX-512 registrations into the interpreter and module tree so they are available in the REPL

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d009037514832e92291a8a98d411f4