### PR TITLE
Add AVX2 bitshift and mask instruction support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ A Rust-based REPL simulator for AVX2 and AVX512 instruction sets with BMI2 exten
   - Load and store operations
   - Arithmetic operations (addition, subtraction)
   - Logical operations (AND, OR, XOR)
+  - Bit shift operations (shared-count and per-lane variants)
+  - Mask extraction and testing helpers
   - Comparison operations
   - Permutation and shuffle operations
 - **BMI2 Extensions**: Includes advanced bit manipulation instructions like `pdep`
@@ -84,6 +86,10 @@ prompt> _mm256_add_epi32(x, x)
 - `_mm256_and_si256` - Bitwise AND
 - `_mm256_or_si256` - Bitwise OR
 - `_mm256_xor_si256` - Bitwise XOR
+- `_mm256_sll_epi32` / `_mm256_srl_epi32` / `_mm256_sra_epi32` - Shared-count shifts
+- `_mm256_sllv_epi32` / `_mm256_srlv_epi32` / `_mm256_srav_epi32` - Per-lane shifts
+- `_mm256_movemask_epi8` - Extract sign bits into a mask
+- `_mm256_testz_si256` / `_mm256_testc_si256` / `_mm256_testnzc_si256` - Mask tests
 - `_mm256_cmpeq_epi32` - Compare packed 32-bit integers for equality
 - `_mm256_permutevar8x32_epi32` - Permute 32-bit integers
 - `_mm256_shuffle_epi8` - Shuffle bytes using control mask

--- a/src/avx2.rs
+++ b/src/avx2.rs
@@ -465,6 +465,128 @@ pub fn register_avx2_instructions(registry: &mut FunctionRegistry) {
         },
     ));
 
+    // shifts with shared count vectors
+    registry.register_instruction(Instruction::new(
+        "_mm256_sll_epi16",
+        vec![ArgType::I256, ArgType::I128],
+        ArgType::I256,
+        |_, args| {
+            require_avx2()?;
+            if args.len() != 2 {
+                return Err("_mm256_sll_epi16 requires 2 arguments".to_string());
+            }
+            let a = args[0].to_i256();
+            let count = args[1].to_i128();
+            let res = unsafe { _mm256_sll_epi16(a, count) };
+            Ok(m256i_to_argument(res))
+        },
+    ));
+    registry.register_instruction(Instruction::new(
+        "_mm256_sll_epi32",
+        vec![ArgType::I256, ArgType::I128],
+        ArgType::I256,
+        |_, args| {
+            require_avx2()?;
+            if args.len() != 2 {
+                return Err("_mm256_sll_epi32 requires 2 arguments".to_string());
+            }
+            let a = args[0].to_i256();
+            let count = args[1].to_i128();
+            let res = unsafe { _mm256_sll_epi32(a, count) };
+            Ok(m256i_to_argument(res))
+        },
+    ));
+    registry.register_instruction(Instruction::new(
+        "_mm256_sll_epi64",
+        vec![ArgType::I256, ArgType::I128],
+        ArgType::I256,
+        |_, args| {
+            require_avx2()?;
+            if args.len() != 2 {
+                return Err("_mm256_sll_epi64 requires 2 arguments".to_string());
+            }
+            let a = args[0].to_i256();
+            let count = args[1].to_i128();
+            let res = unsafe { _mm256_sll_epi64(a, count) };
+            Ok(m256i_to_argument(res))
+        },
+    ));
+    registry.register_instruction(Instruction::new(
+        "_mm256_srl_epi16",
+        vec![ArgType::I256, ArgType::I128],
+        ArgType::I256,
+        |_, args| {
+            require_avx2()?;
+            if args.len() != 2 {
+                return Err("_mm256_srl_epi16 requires 2 arguments".to_string());
+            }
+            let a = args[0].to_i256();
+            let count = args[1].to_i128();
+            let res = unsafe { _mm256_srl_epi16(a, count) };
+            Ok(m256i_to_argument(res))
+        },
+    ));
+    registry.register_instruction(Instruction::new(
+        "_mm256_srl_epi32",
+        vec![ArgType::I256, ArgType::I128],
+        ArgType::I256,
+        |_, args| {
+            require_avx2()?;
+            if args.len() != 2 {
+                return Err("_mm256_srl_epi32 requires 2 arguments".to_string());
+            }
+            let a = args[0].to_i256();
+            let count = args[1].to_i128();
+            let res = unsafe { _mm256_srl_epi32(a, count) };
+            Ok(m256i_to_argument(res))
+        },
+    ));
+    registry.register_instruction(Instruction::new(
+        "_mm256_srl_epi64",
+        vec![ArgType::I256, ArgType::I128],
+        ArgType::I256,
+        |_, args| {
+            require_avx2()?;
+            if args.len() != 2 {
+                return Err("_mm256_srl_epi64 requires 2 arguments".to_string());
+            }
+            let a = args[0].to_i256();
+            let count = args[1].to_i128();
+            let res = unsafe { _mm256_srl_epi64(a, count) };
+            Ok(m256i_to_argument(res))
+        },
+    ));
+    registry.register_instruction(Instruction::new(
+        "_mm256_sra_epi16",
+        vec![ArgType::I256, ArgType::I128],
+        ArgType::I256,
+        |_, args| {
+            require_avx2()?;
+            if args.len() != 2 {
+                return Err("_mm256_sra_epi16 requires 2 arguments".to_string());
+            }
+            let a = args[0].to_i256();
+            let count = args[1].to_i128();
+            let res = unsafe { _mm256_sra_epi16(a, count) };
+            Ok(m256i_to_argument(res))
+        },
+    ));
+    registry.register_instruction(Instruction::new(
+        "_mm256_sra_epi32",
+        vec![ArgType::I256, ArgType::I128],
+        ArgType::I256,
+        |_, args| {
+            require_avx2()?;
+            if args.len() != 2 {
+                return Err("_mm256_sra_epi32 requires 2 arguments".to_string());
+            }
+            let a = args[0].to_i256();
+            let count = args[1].to_i128();
+            let res = unsafe { _mm256_sra_epi32(a, count) };
+            Ok(m256i_to_argument(res))
+        },
+    ));
+
     // variable shifts (no const immediates)
     registry.register_instruction(Instruction::new(
         "_mm256_sllv_epi32",
@@ -539,6 +661,67 @@ pub fn register_avx2_instructions(registry: &mut FunctionRegistry) {
             let count = args[1].to_i256();
             let res = unsafe { _mm256_srav_epi32(a, count) };
             Ok(m256i_to_argument(res))
+        },
+    ));
+
+    // mask extraction and tests
+    registry.register_instruction(Instruction::new(
+        "_mm256_movemask_epi8",
+        vec![ArgType::I256],
+        ArgType::U32,
+        |_, args| {
+            require_avx2()?;
+            if args.len() != 1 {
+                return Err("_mm256_movemask_epi8 requires 1 argument".to_string());
+            }
+            let a = args[0].to_i256();
+            let res = unsafe { _mm256_movemask_epi8(a) } as u64;
+            Ok(Argument::ScalarTyped(ArgType::U32, res))
+        },
+    ));
+    registry.register_instruction(Instruction::new(
+        "_mm256_testz_si256",
+        vec![ArgType::I256, ArgType::I256],
+        ArgType::U32,
+        |_, args| {
+            require_avx2()?;
+            if args.len() != 2 {
+                return Err("_mm256_testz_si256 requires 2 arguments".to_string());
+            }
+            let a = args[0].to_i256();
+            let b = args[1].to_i256();
+            let res = unsafe { _mm256_testz_si256(a, b) } as u64;
+            Ok(Argument::ScalarTyped(ArgType::U32, res))
+        },
+    ));
+    registry.register_instruction(Instruction::new(
+        "_mm256_testc_si256",
+        vec![ArgType::I256, ArgType::I256],
+        ArgType::U32,
+        |_, args| {
+            require_avx2()?;
+            if args.len() != 2 {
+                return Err("_mm256_testc_si256 requires 2 arguments".to_string());
+            }
+            let a = args[0].to_i256();
+            let b = args[1].to_i256();
+            let res = unsafe { _mm256_testc_si256(a, b) } as u64;
+            Ok(Argument::ScalarTyped(ArgType::U32, res))
+        },
+    ));
+    registry.register_instruction(Instruction::new(
+        "_mm256_testnzc_si256",
+        vec![ArgType::I256, ArgType::I256],
+        ArgType::U32,
+        |_, args| {
+            require_avx2()?;
+            if args.len() != 2 {
+                return Err("_mm256_testnzc_si256 requires 2 arguments".to_string());
+            }
+            let a = args[0].to_i256();
+            let b = args[1].to_i256();
+            let res = unsafe { _mm256_testnzc_si256(a, b) } as u64;
+            Ok(Argument::ScalarTyped(ArgType::U32, res))
         },
     ));
 


### PR DESCRIPTION
## Summary
- add shared-count AVX2 shift instructions alongside the existing per-lane variants
- expose AVX2 mask helpers (movemask/test* intrinsics) in the registry
- document new bitshift and mask functionality in the README

## Testing
- cargo fmt
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d4f85f441c832e89601a7f9da6154c