### PR TITLE
Add rustfmt check to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  build:
+    name: Build and Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Rust 1.89+
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.89.0"
+          components: rustfmt
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Check AVX support
+        id: avx
+        run: |
+          if lscpu | grep -qi 'avx'; then
+            echo "AVX_AVAILABLE=true" >> "$GITHUB_ENV"
+            echo "AVX support detected."
+          else
+            echo "AVX_AVAILABLE=false" >> "$GITHUB_ENV"
+            echo "AVX support not detected; tests will be skipped." >&2
+          fi
+
+      - name: Run tests
+        if: env.AVX_AVAILABLE == 'true'
+        run: cargo test --workspace --locked
+
+      - name: Skip tests due to missing AVX
+        if: env.AVX_AVAILABLE != 'true'
+        run: |
+          echo "Skipping cargo test because AVX instructions are unavailable on this runner." && exit 0

--- a/src/bmi2.rs
+++ b/src/bmi2.rs
@@ -131,7 +131,7 @@ pub fn register_bmi2_instructions(registry: &mut FunctionRegistry) {
                     return Err(format!(
                         "_mulx_u32 third argument must be a pointer to a variable, found {:?}",
                         other
-                    ))
+                    ));
                 }
             };
 
@@ -142,7 +142,7 @@ pub fn register_bmi2_instructions(registry: &mut FunctionRegistry) {
                         return Err(format!(
                             "Pointer '{}' must reference a scalar variable, found {:?}",
                             hi_var_name, other
-                        ))
+                        ));
                     }
                 }
             }
@@ -175,7 +175,7 @@ pub fn register_bmi2_instructions(registry: &mut FunctionRegistry) {
                     return Err(format!(
                         "_mulx_u64 third argument must be a pointer to a variable, found {:?}",
                         other
-                    ))
+                    ));
                 }
             };
 
@@ -186,17 +186,14 @@ pub fn register_bmi2_instructions(registry: &mut FunctionRegistry) {
                         return Err(format!(
                             "Pointer '{}' must reference a scalar variable, found {:?}",
                             hi_var_name, other
-                        ))
+                        ));
                     }
                 }
             }
 
             let mut hi_out: u64 = 0;
             let lo = unsafe { _mulx_u64(a, b, &mut hi_out) };
-            ctx.set_var(
-                &hi_var_name,
-                Argument::ScalarTyped(ArgType::U64, hi_out),
-            );
+            ctx.set_var(&hi_var_name, Argument::ScalarTyped(ArgType::U64, hi_out));
             Ok(Argument::ScalarTyped(ArgType::U64, lo))
         },
     ));


### PR DESCRIPTION
## Summary
- add the rustfmt component to the CI toolchain and run `cargo fmt --all -- --check`
- apply `cargo fmt` to the BMI2 instruction implementations so the check passes

## Testing
- cargo fmt --all -- --check
- cargo test --workspace --locked

------
https://chatgpt.com/codex/tasks/task_e_68d6243423a0832eb7b4c1dbb9903737