### PR TITLE
Add file() builtin for memory loading and parse string literals

### DIFF
--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -5,6 +5,7 @@ use crate::bmi2::register_bmi2_instructions;
 use crate::sse2::register_sse2_instructions;
 use std::arch::x86_64::*;
 use std::collections::HashMap;
+use std::fs;
 
 pub struct Interpreter {
     pub variables: HashMap<String, Argument>,
@@ -141,6 +142,23 @@ impl Interpreter {
                 }
 
                 Ok(Argument::Scalar(0))
+            },
+        ));
+
+        registry.register_instruction(Instruction::with_arg_range(
+            "file",
+            vec![],
+            ArgType::Ptr,
+            1,
+            Some(1),
+            |_, args| {
+                if args.len() != 1 {
+                    return Err("file requires exactly 1 argument".to_string());
+                }
+                let path = argument_to_utf8_lossy(&args[0])?;
+                let bytes = fs::read(&path)
+                    .map_err(|err| format!("Failed to read file '{}': {}", path, err))?;
+                Ok(Argument::Memory(bytes))
             },
         ));
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -4,6 +4,8 @@ mod tests {
     use crate::interpreter::{Interpreter, argument_to_utf8_lossy};
     use crate::parser::parse_input;
     use std::convert::TryInto;
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     #[test]
     fn test_parse_simple_function_call() {
@@ -125,6 +127,18 @@ mod tests {
                 }
                 _ => panic!("Expected Call"),
             }
+        }
+    }
+
+    #[test]
+    fn test_parse_string_literal_argument() {
+        let result = parse_input("message = \"Hi\\n\"").unwrap();
+        match result {
+            AST::Var { name, value } => {
+                assert_eq!(name, "message");
+                assert_eq!(value, Argument::Memory(b"Hi\n".to_vec()));
+            }
+            other => panic!("Expected variable assignment, got {:?}", other),
         }
     }
 
@@ -323,6 +337,35 @@ mod tests {
         let scalar_arg = Argument::ScalarTyped(ArgType::U16, scalar_val);
         let scalar_text = argument_to_utf8_lossy(&scalar_arg).unwrap();
         assert_eq!(scalar_text, "Ok");
+    }
+
+    #[test]
+    fn test_file_function_reads_file_into_memory() {
+        let mut interpreter = Interpreter::new();
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let file_path = std::env::temp_dir().join(format!(
+            "avx_explorer_test_{}_{}",
+            std::process::id(),
+            timestamp
+        ));
+        let data = b"File contents for testing";
+        fs::write(&file_path, data).expect("unable to write test file");
+
+        let input = format!("buf = file(\"{}\")", file_path.display());
+        let ast = parse_input(&input).expect("file() call should parse");
+        let result = interpreter
+            .execute(ast)
+            .expect("file() call should execute");
+
+        match result {
+            Argument::Memory(bytes) => assert_eq!(bytes, data),
+            other => panic!("Expected memory result from file(), got {:?}", other),
+        }
+
+        fs::remove_file(&file_path).expect("unable to clean up test file");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- allow parsing of quoted string literals into memory arguments
- add a file() builtin that loads file contents into memory variables
- add unit tests for string literal parsing and file-based memory loading

## Testing
- cargo fmt
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68dab80ae3c0832eb4782698c0ef69a7