### PR TITLE
Add env command for inspecting interpreter state

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -134,6 +134,11 @@ fn handle_line(interpreter: &mut Interpreter, input: &str) -> bool {
         return true;
     }
 
+    if input == "env" {
+        interpreter.dump_environment();
+        return true;
+    }
+
     if input == "exit" {
         return false;
     }


### PR DESCRIPTION
## Summary
- add data structures and helpers to summarize interpreter state without dumping raw memory
- expose an `env` REPL command that prints memory names and register values using the new snapshot API
- cover the environment snapshot helpers with unit tests for memory separation and array previews

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68dac6000390832e9e298140310e763a