### PR TITLE
Zero-pad partial AVX vector loads

### DIFF
--- a/src/avx_512.rs
+++ b/src/avx_512.rs
@@ -70,6 +70,30 @@ fn bytes_to_m512i(bytes: &[u8]) -> __m512i {
     unsafe { std::mem::transmute(lanes) }
 }
 
+fn load_vector_bytes<const N: usize>(
+    memory: &[u8],
+    offset: usize,
+    instr: &str,
+) -> Result<[u8; N], String> {
+    if offset > memory.len() {
+        return Err(format!(
+            "{} reading {} byte(s) at offset {} exceeds memory length {}",
+            instr,
+            N,
+            offset,
+            memory.len()
+        ));
+    }
+
+    let mut buffer = [0u8; N];
+    let available = memory.len() - offset;
+    let to_copy = available.min(N);
+    if to_copy > 0 {
+        buffer[..to_copy].copy_from_slice(&memory[offset..offset + to_copy]);
+    }
+    Ok(buffer)
+}
+
 fn ensure_alignment(offset: usize, alignment: usize, instr: &str) -> Result<(), String> {
     if offset % alignment != 0 {
         Err(format!(
@@ -148,18 +172,8 @@ pub fn register_avx512_instructions(registry: &mut FunctionRegistry) {
             ensure_alignment(offset, 64, "_mm512_load_si512")?;
 
             let memory = clone_memory_from_ptr(ctx, &args[0], "_mm512_load_si512")?;
-            let end = offset
-                .checked_add(64)
-                .ok_or_else(|| "Offset calculation overflowed".to_string())?;
-            if end > memory.len() {
-                return Err(format!(
-                    "_mm512_load_si512 reading 64 byte(s) at offset {} exceeds memory length {}",
-                    offset,
-                    memory.len()
-                ));
-            }
-
-            let vec = bytes_to_m512i(&memory[offset..end]);
+            let bytes = load_vector_bytes::<64>(&memory, offset, "_mm512_load_si512")?;
+            let vec = bytes_to_m512i(&bytes);
             Ok(m512i_to_argument(vec))
         },
     ));
@@ -177,18 +191,8 @@ pub fn register_avx512_instructions(registry: &mut FunctionRegistry) {
 
             let offset = extract_offset(args.get(1))?;
             let memory = clone_memory_from_ptr(ctx, &args[0], "_mm512_loadu_si512")?;
-            let end = offset
-                .checked_add(64)
-                .ok_or_else(|| "Offset calculation overflowed".to_string())?;
-            if end > memory.len() {
-                return Err(format!(
-                    "_mm512_loadu_si512 reading 64 byte(s) at offset {} exceeds memory length {}",
-                    offset,
-                    memory.len()
-                ));
-            }
-
-            let vec = bytes_to_m512i(&memory[offset..end]);
+            let bytes = load_vector_bytes::<64>(&memory, offset, "_mm512_loadu_si512")?;
+            let vec = bytes_to_m512i(&bytes);
             Ok(m512i_to_argument(vec))
         },
     ));


### PR DESCRIPTION
## Summary
- add reusable helpers that zero-pad partial AVX-256 and AVX-512 memory loads instead of erroring on short buffers
- update load instructions to use the helpers so registers are always produced when memory is shorter than the vector width
- add regression tests covering zero-padding behavior for _mm256_loadu_si256 and _mm512_loadu_si512

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68dac91d99b4832eaac965058085735d